### PR TITLE
Remove redundant font-family declarations

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -31,7 +31,6 @@ html{ -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 
 
 body{
-font-family: var(--font-body);
 font-size: clamp(16px, 1.1vw + .2rem, 18px);
 line-height: 1.6;
 color: var(--charcoal);
@@ -40,7 +39,7 @@ margin: 0;
 overflow-x: hidden; /* prevent horizontal overflow sliver */
 }
 
-h1,h2,h3{ font-family: var(--font-head); font-weight: 600; color: var(--smoky-navy); margin: 0 0 .6rem; }
+h1,h2,h3{ font-weight: 600; color: var(--smoky-navy); margin: 0 0 .6rem; }
 h1{ font-size: clamp(2rem, 4vw, 3.25rem); line-height: 1.15; }
 h2{ font-size: clamp(1.5rem, 2.6vw, 2rem); line-height: 1.2; }
 h3{ font-size: clamp(1.25rem, 2vw, 1.5rem); line-height: 1.25; margin-bottom: .5rem; }


### PR DESCRIPTION
## Summary
- remove duplicate font declarations from `assets/css/main.css`
- rely on `assets/css/fonts.css` for early `font-family` settings

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b7564f562c83218ebcd0d3efbd1e3f