### PR TITLE
Remove unused utility helpers

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -303,8 +303,6 @@ a:hover{ color: var(--dusty-rose); text-decoration:underline; }
 /* =========================================================
    10) UTILITIES
    ========================================================= */
-.text-center{ text-align:center; }
-.max-width{ max-width:70ch; margin-inline:auto; }
 .visually-hidden{
   position:absolute !important; width:1px; height:1px; padding:0; margin:-1px;
   overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;


### PR DESCRIPTION
## Summary
- drop `.text-center` and `.max-width` utility classes
- keep `.visually-hidden` unchanged

## Testing
- `npx stylelint assets/css/main.css` *(fails: ConfigurationError: No configuration provided for /workspace/megabirthday/assets/css/main.css)*
- `npx csslint assets/css/main.css` *(fails: various warnings and errors)
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b75b6fbe1883219a336c809864f27f