### PR TITLE
Add minimal mb-form styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -170,6 +170,12 @@ main{ padding-block: clamp(2rem, 4vw, 4rem); }
   padding: 0;
 }
 
+.mb-form{
+  display:block;
+  max-width:100%;
+  margin:0 auto;
+}
+
 .mb-form__row{ display:flex; align-items:center; justify-content:space-between; gap:.75rem; }
 
 .mb-link{


### PR DESCRIPTION
## Summary
- add base `.mb-form` selector with block display, full-width, and centered margin to keep form class as a styling hook

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:css` *(fails: important is not a valid option)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f38377f88321814e094432692896